### PR TITLE
Use CMake for git submodules

### DIFF
--- a/depends/common/chailove/CMakeLists.txt
+++ b/depends/common/chailove/CMakeLists.txt
@@ -3,6 +3,15 @@ project(chailove)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 
+include(FetchContent)
+FetchContent_Declare(
+    libretrochailove
+    GIT_REPOSITORY https://github.com/libretro/libretro-chailove.git
+    GIT_TAG 6cf08ec1c0a441f2ebeb942ec0a28d9037b83816
+    SOURCE_DIR chailove
+)
+FetchContent_MakeAvailable(libretrochailove)
+
 include(ExternalProject)
 
 string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UC)

--- a/depends/common/chailove/chailove.txt
+++ b/depends/common/chailove/chailove.txt
@@ -1,1 +1,0 @@
-chailove https://github.com/kodi-game/libretro-chailove/archive/e970f1191855cc6a4de6103f78506d60a08532d7.tar.gz

--- a/depends/common/chailove/chailove.txt
+++ b/depends/common/chailove/chailove.txt
@@ -1,0 +1,1 @@
+chailove https://github.com/kodi-game/libretro-chailove/archive/e970f1191855cc6a4de6103f78506d60a08532d7.tar.gz


### PR DESCRIPTION
This demonstrates using CMake's FetchContent to download chailove with all the correct submodules. The `SOURCE_DIR` is where the files will be downloaded to.

I'm unable where the files should be downloaded to, so we would need to update `SOURCE_DIR`. Does this work on the related build systems?

